### PR TITLE
Clean up brightness controls

### DIFF
--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -107,7 +107,7 @@ app.get('/api/brightness/', function(req, res) {
     res.send(global_brightness.toString()); // Cast to string; a number implies an http status code
 });
 app.put('/api/brightness/:brightness', function(req, res) {
-    global_brightness = req.params.brightness;
+    global_brightness = Math.min(1, Math.max(0, parseFloat(req.params.brightness)));
     client.brightness = global_brightness;
     storage.setItem(GLOBAL_BRIGHTNESS_CONFIG_KEY, global_brightness).catch(err => console.error('Failed to save brightness:', err));
     res.sendStatus(200);

--- a/packages/ui/src/App.jsx
+++ b/packages/ui/src/App.jsx
@@ -3,6 +3,7 @@ import { useStore } from './state/store';
 import { subscribeStatus } from './api/lightStream';
 import SceneGrid from './components/switcher/SceneGrid';
 import Editor from './components/editor/Editor';
+import BrightnessSlider from './components/switcher/BrightnessSlider';
 
 function parseHash() {
   // Scene ids are 8-char hex for new scenes, but migrated presets keep
@@ -39,13 +40,16 @@ export default function App() {
   return (
     <div className="app">
       <header className="app-header">
-        <button className="app-title" onClick={closeEditor} aria-label="Back to scenes">
-          Lightpanel
-        </button>
-        <span
-          className={`ws-dot${wsConnected ? ' ws-dot--on' : ''}`}
-          title={wsConnected ? 'Live preview connected' : 'Live preview disconnected'}
-        />
+        <div className="app-header-brand">
+          <button className="app-title" onClick={closeEditor} aria-label="Back to scenes">
+            Lightpanel
+          </button>
+          <span
+            className={`ws-dot${wsConnected ? ' ws-dot--on' : ''}`}
+            title={wsConnected ? 'Live preview connected' : 'Live preview disconnected'}
+          />
+        </div>
+        {loaded && <BrightnessSlider />}
       </header>
       {!loaded ? (
         <div className="app-loading">Connecting…</div>

--- a/packages/ui/src/components/editor/Editor.jsx
+++ b/packages/ui/src/components/editor/Editor.jsx
@@ -5,7 +5,6 @@ import PreviewStage from './PreviewStage';
 import LayerStack from './LayerStack';
 import ParamPanel from './ParamPanel';
 import EffectPicker from './EffectPicker';
-import BrightnessSlider from '../switcher/BrightnessSlider';
 import { newId as newLayerId } from '../../lib/id';
 
 export default function Editor({ sceneId, onClose }) {
@@ -131,7 +130,6 @@ export default function Editor({ sceneId, onClose }) {
           aria-label="Scene name"
         />
         <div className="editor-toolbar-right">
-          <BrightnessSlider />
           <button className="btn btn-ghost" onClick={handleDuplicateScene}>Duplicate</button>
           <button className="btn btn-ghost btn-danger" onClick={handleDeleteScene}>Delete scene</button>
         </div>

--- a/packages/ui/src/components/switcher/BrightnessSlider.jsx
+++ b/packages/ui/src/components/switcher/BrightnessSlider.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useStore } from '../../state/store';
-import { sliderToValue, valueToSlider } from '../../lib/perceptual';
 
 export default function BrightnessSlider() {
   const brightness = useStore((s) => s.brightness);
@@ -12,11 +11,11 @@ export default function BrightnessSlider() {
       <input
         type="range"
         min="0"
-        max="10"
+        max="1"
         step="0.01"
-        value={valueToSlider(brightness)}
-        onChange={(e) => setBrightness(sliderToValue(Number(e.target.value)))}
-        aria-label="Global brightness"
+        value={brightness}
+        onChange={(e) => setBrightness(Number(e.target.value))}
+        aria-label="Brightness"
       />
       <span className="brightness-value">{Number(brightness).toFixed(2)}</span>
     </div>

--- a/packages/ui/src/components/switcher/SceneGrid.jsx
+++ b/packages/ui/src/components/switcher/SceneGrid.jsx
@@ -2,7 +2,6 @@ import React, { useRef } from 'react';
 import { useStore } from '../../state/store';
 import { api } from '../../api/client';
 import SceneCard from './SceneCard';
-import BrightnessSlider from './BrightnessSlider';
 
 export default function SceneGrid({ onEdit }) {
   const scenes = useStore((s) => s.scenes);
@@ -92,18 +91,15 @@ export default function SceneGrid({ onEdit }) {
         </div>
       </div>
       <div className="switcher-footer">
-        <BrightnessSlider />
-        <div className="switcher-footer-actions">
-          <button className="btn btn-ghost" onClick={handleExport}>Export</button>
-          <button className="btn btn-ghost" onClick={() => importInputRef.current.click()}>Import</button>
-          <input
-            ref={importInputRef}
-            type="file"
-            accept=".json,application/json"
-            style={{ display: 'none' }}
-            onChange={handleImportFile}
-          />
-        </div>
+        <button className="btn btn-ghost" onClick={handleExport}>Export</button>
+        <button className="btn btn-ghost" onClick={() => importInputRef.current.click()}>Import</button>
+        <input
+          ref={importInputRef}
+          type="file"
+          accept=".json,application/json"
+          style={{ display: 'none' }}
+          onChange={handleImportFile}
+        />
       </div>
     </>
   );

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -32,8 +32,23 @@ body {
 .app-header {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 10px 20px;
+  flex-wrap: wrap;
   padding: 14px 0;
+}
+
+.app-header-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Shared brightness control lives in the header, identical on both views.
+   Grows to fill the row on desktop; wraps to its own full-width row when
+   the brand and slider no longer fit side by side. */
+.app-header .brightness {
+  flex: 1 1 240px;
+  min-width: 200px;
 }
 
 .app-title {
@@ -156,9 +171,10 @@ body {
 .switcher-footer {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 8px;
   margin-top: 22px;
-  flex-wrap: wrap;
+  padding-top: 22px;
+  border-top: 1px solid var(--border);
 }
 
 .brightness {
@@ -177,8 +193,6 @@ body {
   width: 36px;
   text-align: right;
 }
-
-.switcher-footer-actions { display: flex; gap: 8px; }
 
 /* ── Range inputs ── */
 
@@ -246,7 +260,6 @@ input[type="range"]::-moz-range-thumb {
   gap: 12px;
   margin-left: auto;
 }
-.editor-toolbar-right .brightness { min-width: 200px; flex: none; }
 
 .preview-stage {
   position: relative;


### PR DESCRIPTION
## What

Simplifies the panel's brightness controls, which previously looked like two separate controls plus behaved inconsistently.

- **Cap global brightness at 1.0.** The slider dropped its old 0–10 arctangent "overdrive" range and is now a plain linear 0–1 control. The `PUT /api/brightness/:brightness` route now parses and clamps to `[0, 1]` server-side, so the cap is authoritative rather than just a UI bound (the route previously stored the raw, unvalidated string).
- **One shared control in the app header.** The brightness slider now lives in the shared `.app-header` (next to the "Lightpanel" title and the connection light), so it is literally the same element in the same position on both the switcher and editor views. Previously `BrightnessSlider` was rendered a second time in the editor toolbar next to Duplicate/Delete scene — same global value, but it read as scene-scoped and caused confusion about how "per-scene" and "global" brightness interacted (they never did — there is no per-scene brightness field).
- **Relabeled** "Global brightness" → **"Brightness"**.
- **Responsive header.** The slider fills the remaining header width on desktop and wraps to its own full-width row on narrow screens.
- **Home footer** keeps only Export/Import, separated from the scene grid by a top border.

## Why

The editor's "brightness" slider was the same global value as the home page's, which was unclear, and the slider allowed values well above 1.0 with no server-side clamp. Consolidating to a single header control removes the duplication and makes the shared, global nature obvious.

## Out of scope / unchanged

The **wavelet effect's own "Brightness" param** is a separate schema/control path (rendered via `RangeControl`, applied as an oscillation envelope and clamped only at final pixel output). It intentionally still allows values above 1.0, which is integral to additive layer stacking — left untouched.

## Testing

- UI (`packages/ui`): `npm test` — 7 passing.
- Server (`packages/server`): `node --test` — 39 passing.
- Verified live in the browser on both views and at mobile/desktop widths: header wraps to full-width on mobile, no console errors, and `PUT /api/brightness/5` clamps the stored value to `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)