### PR TITLE
Render previews pre-brightness (pre-fader meter)

### DIFF
--- a/API.md
+++ b/API.md
@@ -173,7 +173,7 @@ The `wavelet` effect renders one sinusoidal wave radiating from a point; stack s
 
 A WebSocket server on port `3001` streams pixel state in both virtual and hardware modes.
 
-**v1 (default):** on connect, each message is a JSON array of 240 `[r, g, b]` triples (0–255) — the composite output after brightness — at ~30 FPS. The most recent frame is replayed to new connections.
+**v1 (default):** on connect, each message is a JSON array of 240 `[r, g, b]` triples (0–255) — the composite output **before** global brightness — at ~30 FPS. The most recent frame is replayed to new connections. Streamed frames are deliberately pre-fader: previews always show the scene at full brightness, and only the panel dims with `/api/brightness`.
 
 **v2 (layer previews):** send
 
@@ -187,7 +187,7 @@ and while that scene is active you receive, at ~15 FPS:
 { "type": "frame", "composite": [[r,g,b], ...], "layers": { "<layerId>": [[r,g,b], ...] } }
 ```
 
-instead of v1 frames. Layer frames are pre-opacity and pre-brightness (thumbnails of faint layers stay legible). Send `{ "type": "unsubscribe_layers" }` to revert to v1.
+instead of v1 frames. `composite` is pre-brightness like v1; layer frames are additionally pre-opacity (thumbnails of faint layers stay legible). Send `{ "type": "unsubscribe_layers" }` to revert to v1.
 
 ## Migration from the preset API
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ Key modules:
 - `engine/scene-store.js` — scene list + active id, `preprocess()` on every write (attaches `_prepared`, `_blend`, `_displayLayers` so the hot loop never parses/filters), debounced writes (2s trailing; flushed on SIGINT/SIGTERM).
 - `engine/json-store.js` — **scenes persist to `packages/server/.node-persist/scenes-v2.json` via atomic tmp+fsync+rename with a `.bak` fallback**, NOT node-persist: node-persist's plain `fs.writeFile` lost scene data to a power cut once. node-persist (with `forgiveParseErrors: true`) remains only for brightness and legacy keys (`wave_config`, old `scenes_v2`), which the store falls back to when the scene file is absent.
 - `engine/migrate.js` — one-time `wave_config` → scenes conversion (one wavelet layer per wavelet, `add` blend). Old key kept for rollback.
-- `engine/broadcast.js` — the only WebSocket server (port 3001), both modes. v1: bare `[[r,g,b],…]` composite frames ~30 FPS, last frame replayed to new connections. v2: `subscribe_layers` → `{type:"frame", composite, layers}` at ~15 FPS, only serialised while subscribers exist.
+- `engine/broadcast.js` — the only WebSocket server (port 3001), both modes. Serialises from `compositor.composite`, i.e. **pre-brightness** — UI previews are a pre-fader meter and never dim; only the panel does. v1: bare `[[r,g,b],…]` composite frames ~30 FPS, last frame replayed to new connections. v2: `subscribe_layers` → `{type:"frame", composite, layers}` at ~15 FPS, only serialised while subscribers exist.
 - `effects/*.js` — one module per effect: `{type, name, schema, defaults, prepare(params), createInstance(ctx)}`. `prepare()` runs on the API write path (hex→rgb, LUTs); `createInstance()` holds per-layer animation state and is recreated **only** on effectType change (param edits must not reset particles). Hot loops are allocation-free.
-- `opc.js` / `virtual-opc.js` — pixel sinks; swapped on `VIRTUAL` env var. Hardware buffer has a 4-byte OPC header (broadcast uses `headerOffset`).
+- `opc.js` / `virtual-opc.js` — pixel sinks; swapped on `VIRTUAL` env var. Hardware buffer has a 4-byte OPC header; broadcast doesn't care, it reads the compositor instead.
 - `layout.json` — 240 LED positions; x ∈ ±3.625, z ∈ ±0.875, 0.25 spacing. Effect `y` params negate z (`dz = pz + y`).
 
 ## UI Architecture (`packages/ui/`)

--- a/packages/server/app.js
+++ b/packages/server/app.js
@@ -13,10 +13,9 @@ var createScenesRouter = require('./routes/scenes');
 
 var compositor = new Compositor(client, model);
 
-// The hardware OPC buffer carries a 4-byte protocol header; virtual doesn't.
-var broadcaster = new Broadcaster(client, model.length, {
-    headerOffset: process.env.VIRTUAL ? 0 : 4,
-});
+// Previews stream the compositor's pre-brightness composite, so they stay
+// legible (pre-fader meter) while only the panel dims.
+var broadcaster = new Broadcaster(compositor, model.length);
 
 var express = require('express');
 var cors = require('cors');
@@ -128,7 +127,7 @@ function tick() {
     if (scene) {
         compositor.renderFrame(scene, Date.now());
         broadcaster.tick();
-        broadcaster.tickLayers(scene, compositor);
+        broadcaster.tickLayers(scene);
         offRendered = false;
     } else if (!offRendered) {
         compositor.renderBlack();

--- a/packages/server/engine/broadcast.js
+++ b/packages/server/engine/broadcast.js
@@ -1,8 +1,14 @@
 /*
  * Single WebSocket broadcaster (port 3001) for both hardware and virtual
  * modes — replaces the WSS that lived inside virtual-opc.js plus the
- * hardware-mode mirror in app.js (which assumed a 4-byte OPC header that
- * virtual buffers don't have; headerOffset makes that explicit).
+ * hardware-mode mirror in app.js.
+ *
+ * Frames are serialised from compositor.composite, i.e. *before* global
+ * brightness is applied on the client.setPixel() write path: the UI
+ * previews are a pre-fader meter, always showing the scene as authored,
+ * and only the panel itself dims. (Reading the compositor rather than
+ * client.pixelBuffer also sidesteps the 4-byte OPC header that hardware
+ * buffers carry and virtual ones don't.)
  *
  * v1 protocol (default): bare [[r,g,b], ...] JSON frames of the
  * composite, throttled to ~30 fps. New connections get the last frame
@@ -29,10 +35,9 @@ function clamp255(v) {
 }
 
 class Broadcaster {
-    constructor(client, numPixels, options) {
-        this.client = client;
+    constructor(compositor, numPixels, options) {
+        this.compositor = compositor;
         this.numPixels = numPixels;
-        this.headerOffset = (options && options.headerOffset) || 0;
         this._pixelArray = null;
         this._lastMsg = null;
         this._lastSent = 0;
@@ -59,7 +64,7 @@ class Broadcaster {
         });
     }
 
-    _serialiseBuffer(buf, offset, target) {
+    _serialiseBuffer(buf, target) {
         var n = this.numPixels;
         if (!target || target.length !== n) {
             target = new Array(n);
@@ -67,7 +72,7 @@ class Broadcaster {
         }
         for (var i = 0; i < n; i++) {
             var triple = target[i];
-            var o = offset + i * 3;
+            var o = i * 3;
             triple[0] = clamp255(buf[o]);
             triple[1] = clamp255(buf[o + 1]);
             triple[2] = clamp255(buf[o + 2]);
@@ -80,11 +85,11 @@ class Broadcaster {
         var now = Date.now();
         if (!force && now - this._lastSent < FRAME_INTERVAL_MS) return;
         if (this.wss.clients.size === 0 && !force) return;
-        var buf = this.client.pixelBuffer;
+        var buf = this.compositor.composite;
         if (!buf) return;
         this._lastSent = now;
 
-        this._pixelArray = this._serialiseBuffer(buf, this.headerOffset, this._pixelArray);
+        this._pixelArray = this._serialiseBuffer(buf, this._pixelArray);
         this._lastMsg = JSON.stringify(this._pixelArray);
 
         var msg = this._lastMsg;
@@ -95,7 +100,7 @@ class Broadcaster {
 
     // Layer broadcast (v2), called every render tick with the active scene;
     // does nothing unless someone subscribed to that scene's layers.
-    tickLayers(scene, compositor, force) {
+    tickLayers(scene, force) {
         var now = Date.now();
         if (!force && now - this._lastLayerSent < LAYER_FRAME_INTERVAL_MS) return;
 
@@ -108,15 +113,15 @@ class Broadcaster {
         if (subscribers.length === 0) return;
         this._lastLayerSent = now;
 
-        var buf = this.client.pixelBuffer;
-        this._pixelArray = this._serialiseBuffer(buf, this.headerOffset, this._pixelArray);
+        var buf = this.compositor.composite;
+        this._pixelArray = this._serialiseBuffer(buf, this._pixelArray);
 
         var layers = {};
         for (var i = 0; i < scene.layers.length; i++) {
             var layer = scene.layers[i];
-            var layerBuf = compositor.getLayerBuffer(layer.id);
+            var layerBuf = this.compositor.getLayerBuffer(layer.id);
             if (!layerBuf) continue;
-            var arr = this._serialiseBuffer(layerBuf, 0, this._layerArrays.get(layer.id));
+            var arr = this._serialiseBuffer(layerBuf, this._layerArrays.get(layer.id));
             this._layerArrays.set(layer.id, arr);
             layers[layer.id] = arr;
         }

--- a/packages/server/virtual-opc.js
+++ b/packages/server/virtual-opc.js
@@ -1,8 +1,10 @@
 /*
  * Virtual OPC client — drop-in replacement for opc.js when no Fadecandy
  * is attached. Just a pixel-buffer sink: brightness and clamping are
- * applied exactly like the real client, and engine/broadcast.js reads
- * pixelBuffer to feed the browser visualiser (it owns the WebSocket now).
+ * applied exactly like the real client. The browser visualiser is fed by
+ * engine/broadcast.js (which owns the WebSocket) straight from the
+ * compositor, so pixelBuffer here goes nowhere — it only keeps the
+ * virtual client behaviourally identical to the hardware one.
  */
 
 var fs = require('fs');


### PR DESCRIPTION
## Why

The scene-card thumbnails on the switcher and the big PreviewStage in the editor all dimmed along with the global brightness control. At low brightness they became nearly unreadable, which makes editing a scene while the panel is dim impractical.

Previews should behave like a **pre-fader meter** — always showing the scene as authored. Only the physical LED panel should respond to global brightness.

## What changed

The UI does no brightness maths at all; the dimming was baked into the frames the server broadcasts. `engine/broadcast.js` serialised `client.pixelBuffer`, which `opc.js` / `virtual-opc.js` have already multiplied by `client.brightness`.

- **`engine/broadcast.js`** — takes the `Compositor` instead of the OPC client and serialises `compositor.composite`, the pre-brightness Float32 composite. `_serialiseBuffer()` already runs values through `clamp255()`, which is exactly what `setPixel()` used to do, so additive over-255 values are handled identically.
- **`headerOffset` removed** (here and in `app.js`) — it only existed because the hardware `pixelBuffer` carries a 4-byte OPC header; `compositor.composite` is a bare `Float32Array` in both modes.
- `tickLayers()` drops its now-redundant `compositor` argument. Per-layer frames were already pre-brightness, so layer thumbnails are unaffected.
- Comment/doc updates in `API.md`, `CLAUDE.md`, and `virtual-opc.js`.

**The hardware output path is untouched** — `client.brightness` still scales `pixelBuffer` in `opc.js` / `virtual-opc.js`, and `/api/brightness` is unchanged.

## Reviewer notes

`compositor.composite` is unclamped float (additive blending can exceed 255), which is why the `clamp255()` in `_serialiseBuffer()` matters. Previously the clamp happened twice — once in `setPixel()`, once on serialise.

## Verification

- `npm test` in `packages/server` — 39/39 pass.
- Ran the app in virtual mode. At global brightness **0.10**, the editor PreviewStage, layer thumbnail, and switcher card previews all render at full brightness. A direct WebSocket read at brightness 0.1 gave a peak channel of **221** (previously it would have been capped near 26).
- Off state (`PUT /api/active_scene {"id": null}`) still drives previews to a peak of **0**, so the forced `broadcaster.tick(true)` path works.
- No browser console errors, no server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)