### PR TITLE
Add power-undervoltage diagnostic tooling for Pi lockups

### DIFF
--- a/packages/server/power-monitor.service
+++ b/packages/server/power-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NeoPixel Light Panel - power/brightness correlation monitor
+After=network.target lightpanel.service
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/github/neopixel-light-panel/packages/server
+ExecStart=/home/pi/github/neopixel-light-panel/packages/server/scripts/power-monitor.sh
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/server/power-watch.service
+++ b/packages/server/power-watch.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NeoPixel Light Panel - kernel undervoltage watcher
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/github/neopixel-light-panel/packages/server
+ExecStart=/home/pi/github/neopixel-light-panel/packages/server/scripts/power-watch.sh
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/server/scripts/power-monitor.sh
+++ b/packages/server/scripts/power-monitor.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Polls Pi undervoltage/thermal status plus current panel brightness/scene,
+# for correlating power events with what the panel was doing at the time.
+# Exact-moment undervoltage detection lives in power-watch.sh instead — this
+# loop is for correlation, not detection, so a 1s poll is fine even though
+# the underlying vcgencmd flags are latched (see plan/README for why).
+set -u
+
+LOG_FILE="${POWER_MONITOR_LOG:-$HOME/power-monitor.log}"
+API_BASE="${LIGHTPANEL_API:-http://localhost:3000}"
+POLL_SECONDS="${POWER_MONITOR_INTERVAL:-1}"
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "timestamp,undervoltage_now,undervoltage_since_boot,freq_capped_now,throttled_now,cpu_temp_c,brightness,active_scene_id" >> "$LOG_FILE"
+fi
+
+has_vcgencmd=0
+command -v vcgencmd >/dev/null 2>&1 && has_vcgencmd=1
+
+while true; do
+  timestamp=$(date -Iseconds)
+
+  if [ "$has_vcgencmd" -eq 1 ]; then
+    throttled_hex=$(vcgencmd get_throttled 2>/dev/null | sed -n 's/^throttled=//p')
+    throttled_dec=$((throttled_hex))
+    undervoltage_now=$(((throttled_dec >> 0) & 1))
+    freq_capped_now=$(((throttled_dec >> 1) & 1))
+    throttled_now=$(((throttled_dec >> 2) & 1))
+    undervoltage_since_boot=$(((throttled_dec >> 16) & 1))
+    cpu_temp_c=$(vcgencmd measure_temp 2>/dev/null | sed -n "s/temp=\([0-9.]*\)'C/\1/p")
+  else
+    undervoltage_now="n/a"
+    freq_capped_now="n/a"
+    throttled_now="n/a"
+    undervoltage_since_boot="n/a"
+    cpu_temp_c="n/a"
+  fi
+
+  brightness=$(curl -s -m 2 "$API_BASE/api/brightness" 2>/dev/null)
+  [ -z "$brightness" ] && brightness="n/a"
+
+  active_scene_json=$(curl -s -m 2 "$API_BASE/api/active_scene" 2>/dev/null)
+  active_scene_id=$(printf '%s' "$active_scene_json" | grep -oE '"id":"[^"]*"' | sed -E 's/"id":"([^"]*)"/\1/')
+  if [ -z "$active_scene_id" ]; then
+    active_scene_id=$(printf '%s' "$active_scene_json" | grep -oE '"id":[a-zA-Z0-9_]*' | sed -E 's/"id"://')
+  fi
+  [ -z "$active_scene_id" ] && active_scene_id="n/a"
+
+  echo "$timestamp,$undervoltage_now,$undervoltage_since_boot,$freq_capped_now,$throttled_now,$cpu_temp_c,$brightness,$active_scene_id" >> "$LOG_FILE"
+
+  sleep "$POLL_SECONDS"
+done

--- a/packages/server/scripts/power-watch.sh
+++ b/packages/server/scripts/power-watch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Streams the kernel log for undervoltage/voltage messages as they happen,
+# instead of sampling for them. journalctl -kf is a live follow (push, not
+# poll), so it can't miss a transient dip between checks the way a polling
+# loop could if the Pi freezes before its next tick.
+set -u
+
+LOG_FILE="${POWER_WATCH_LOG:-$HOME/power-watch.log}"
+
+if ! command -v journalctl >/dev/null 2>&1; then
+  echo "journalctl not found; power-watch.sh only works on the Pi (systemd journal)." >&2
+  exit 1
+fi
+
+journalctl -kf -o short-precise | grep --line-buffered -i volt >> "$LOG_FILE"


### PR DESCRIPTION
## Summary
- The Pi and 240-LED panel share one 5V/10A PSU; a bright frame can push LED current draw (up to ~14.4A for 240 pixels at full white) past what the supply can deliver, sagging the rail enough to brown out the Pi — matching the observed symptom of stutter followed by a hard freeze that needs a physical power cycle.
- Adds two standalone systemd services meant to be left running on the Pi to confirm/rule out this diagnosis, independent of the main app so they keep working even if `lightpanel.service` is what's frozen:
  - `packages/server/scripts/power-monitor.sh` — polls `vcgencmd get_throttled`/`measure_temp` plus the panel's current brightness and active scene (via the existing HTTP API) every second, for correlating undervoltage/throttle events with what the panel was doing.
  - `packages/server/scripts/power-watch.sh` — streams `journalctl -kf` for kernel undervoltage messages live, so a brief dip between polls can't be missed the way it could with polling alone.
- Purely additive tooling — no changes to the render loop, compositor, or API.

## Deploy on the Pi
```bash
git pull
sudo cp packages/server/power-monitor.service packages/server/power-watch.service /etc/systemd/system/
sudo systemctl enable --now power-monitor.service power-watch.service
sudo mkdir -p /var/log/journal && sudo systemctl restart systemd-journald
```
The last step makes the journal persistent across reboots (Raspberry Pi OS defaults to volatile/RAM-only), which the previous-boot cross-check (`journalctl -k -b -1`) depends on.

## Test plan
- [x] Verified `power-monitor.sh` locally against the `VIRTUAL=1` dev server — correctly logs brightness/active scene, and gracefully reports `n/a` for `vcgencmd` fields when absent (off-Pi).
- [x] Sanity-checked the `get_throttled` bitmask decode arithmetic against a known example value.
- [ ] Real confirmation happens on the Pi itself: leave both services running, wait for the next natural lockup, and check `power-watch.log` / `power-monitor.log` around the freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)