### PR TITLE
Confirm scene deletion in the page, not in a browser dialog

### DIFF
--- a/packages/ui/src/components/editor/Editor.jsx
+++ b/packages/ui/src/components/editor/Editor.jsx
@@ -22,12 +22,15 @@ export default function Editor({ sceneId, onClose }) {
   const [selectedLayerId, setSelectedLayerId] = useState(null);
   const [picking, setPicking] = useState(false);
   const [name, setName] = useState(scene ? scene.name : '');
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   // Editing implies looking at it: activate the scene so the panel (and
   // the live preview) show what's being edited.
   useEffect(() => {
     if (!scene) loadSceneDetail(sceneId).catch(() => onClose());
     if (activeSceneId !== sceneId) activateScene(sceneId);
+    // Never carry an armed delete across to a different scene.
+    setConfirmingDelete(false);
     setLayerScene(sceneId);
     // On the way out, re-render just this scene's card. Only one scene can
     // have changed, so the switcher never refetches the whole library.
@@ -103,8 +106,19 @@ export default function Editor({ sceneId, onClose }) {
     if (name !== scene.name) updateScene(sceneId, { ...scene, name });
   }
 
+  // Two clicks, in the page. This used to be a window.confirm, which is the
+  // one thing in the app that asked the browser for UI — and a browser is free
+  // to refuse: iOS runs this from the Home Screen (the manifest says
+  // display: standalone) where confirm() can return false without ever
+  // appearing, and Chrome's "prevent additional dialogs" checkbox does the same
+  // on desktop. Either way the button silently did nothing while every other
+  // control kept working, which is exactly how it was reported.
   async function handleDeleteScene() {
-    if (!window.confirm(`Delete scene "${scene.name}"?`)) return;
+    if (!confirmingDelete) {
+      setConfirmingDelete(true);
+      return;
+    }
+    setConfirmingDelete(false);
     await deleteScene(sceneId);
     onClose();
   }
@@ -132,7 +146,15 @@ export default function Editor({ sceneId, onClose }) {
         />
         <div className="editor-toolbar-right">
           <button className="btn btn-ghost" onClick={handleDuplicateScene}>Duplicate</button>
-          <button className="btn btn-ghost btn-danger" onClick={handleDeleteScene}>Delete scene</button>
+          <button
+            className={`btn btn-ghost btn-danger${confirmingDelete ? ' btn-danger-armed' : ''}`}
+            onClick={handleDeleteScene}
+            onBlur={() => setConfirmingDelete(false)}
+            onKeyDown={(e) => { if (e.key === 'Escape') setConfirmingDelete(false); }}
+            aria-label={confirmingDelete ? `Confirm deleting scene ${scene.name}` : 'Delete scene'}
+          >
+            {confirmingDelete ? 'Really delete?' : 'Delete scene'}
+          </button>
         </div>
       </div>
 

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -91,6 +91,14 @@ body {
 .btn:active { transform: scale(0.98); }
 .btn-ghost { background: transparent; }
 .btn-danger { color: var(--danger); border-color: rgba(226, 75, 74, 0.4); }
+/* The armed half of the two-click delete: filled, so "one more click and it's
+   gone" is obvious at a glance and can't be mistaken for the resting state. */
+.btn-danger-armed {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+}
+.btn-danger-armed:hover { border-color: var(--danger); }
 
 /* ── Scene grid / cards ── */
 


### PR DESCRIPTION
## The bug

The **Delete scene** button on the editor page did nothing — no error, no network request, nothing in the console.

It was gated on `window.confirm(...)`, and a browser is free to refuse that dialog. When it does, `confirm()` returns `false` and the handler returns immediately. Two ways this app hits it:

- `packages/ui/public/site.webmanifest` declares `"display": "standalone"`. Added to an iPhone Home Screen, the app runs in standalone mode, where `confirm()` is unreliable and can return `false` without ever appearing.
- On desktop Chrome, ticking *"Prevent this page from creating additional dialogs"* — which appears after a few dialogs — does the same thing silently for the life of the tab.

No commit ever touched this code, which is why it had been broken for an unknown length of time: the environment changed, not the code. It also presented as one broken button rather than a broken page because **this was the only native dialog in the entire UI** — deleting a *layer* has never asked for confirmation at all.

## The fix

Confirm in the page. First click arms the button (`Really delete?`, filled red), second click deletes. It disarms on blur, on Escape, and on switching scenes, so an armed state can never follow you somewhere unexpected.

This matches the app's existing character — no modals, no save buttons — and depends on nothing the browser can decline to render.

## Verification

The browser used for testing suppresses native dialogs the same way, so it reproduced the original symptom exactly. With `confirm()` instrumented to prove it is never called:

- first click arms and deletes nothing (still on the editor, no request)
- second click fires `DELETE /api/scenes/:id → 200`, returns to the switcher, scene gone server-side
- all three disarm paths (blur, Escape, scene change) confirmed, with the scene intact throughout

Server suite 77 pass, UI suite 74 pass.

## Note

No automated test covers this. `packages/ui` has no component-test setup — all 8 suites are pure `lib` tests, with no testing-library or jsdom — and adding that infrastructure for one button seemed disproportionate to the fix. Happy to add it separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)