### PR TITLE
Make a scene card's preview the shape of the panel

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -123,8 +123,13 @@ body {
 .scene-card:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 2px; }
 .scene-card--active { border: 2px solid var(--accent); padding: 9px; }
 
+/* Matches the panel's 30x8, like the picker tile and the editor's stage. A
+   fixed height here made the box column-width x that height, so the 300x80
+   canvas scaled non-uniformly and the LEDs came out as ovals — by 26% at a
+   375px phone, and sawtoothing as the column count snapped. */
 .scene-card-preview {
-  height: 64px;
+  width: 100%;
+  aspect-ratio: 30 / 8;
   border-radius: 6px;
   overflow: hidden;
   background: #0d0d0f;
@@ -164,7 +169,12 @@ body {
   align-items: center;
   justify-content: center;
   gap: 4px;
-  min-height: 122px;
+  /* A floor, not a match: grid stretch already levels a row, and now that a
+     scene card's height follows its preview's aspect this has to stay under
+     the shortest real card (~103px, in the 2-column band just above 344px) or
+     it pads out the row it sits in. It only does any work when Off and New
+     are alone — an empty library. */
+  min-height: 100px;
   color: var(--text-dim);
 }
 .scene-card--off .scene-card-name,
@@ -673,7 +683,6 @@ input[type="range"]::-moz-range-thumb {
 
 @media (max-width: 640px) {
   .scene-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); }
-  .scene-card-preview { height: 52px; }
   .scene-card-edit { display: none; }
   .brightness input[type="range"]::-webkit-slider-thumb { width: 22px; height: 22px; margin-top: -9px; }
 }


### PR DESCRIPTION
Closes #21.

## What was wrong

`.scene-card-preview` was a fixed height (64px, 52px under 640px) while its width followed the grid column, so the displayed box was *column width × that height* and the 300×80 canvas — 3.75:1, the panel's true 30×8 — scaled into it non-uniformly. The LEDs rendered as ellipses, and because the bloom geometry comes from the same buffer, the glow stretched with them.

`.scene-grid` is `repeat(auto-fill, minmax(210px, 1fr))`, so the column count snaps as the window crosses each threshold and the error sawtooths rather than drifting.

| viewport | before | after |
|---|---|---|
| 1280px | 236×64 = 3.69 | 236×63 = **3.75** |
| 900px | 254×64 = 3.97 | 254×68 = **3.75** |
| 700px | 193×52 = 3.71 | 193×51 = **3.75** |
| 375px | 144×52 = 2.76 | 144×38 = **3.75** |

375px is the worst of the range (26% squashed) and the width where the ovals are unmistakable.

## The fix

`aspect-ratio: 30 / 8`, the pattern already used by `.effect-picker-preview` and `.preview-stage` — both correct at every width. The scene card was the outlier. No height clamp beside it: the comment above `.preview-stage` records that pairing `max-height` with `aspect-ratio` is what stretched that one 19% sideways.

## What a reviewer should know

The Off and New cards needed retuning. Their `min-height: 122px` was sized against the old fixed preview; now that a card's height follows its preview's aspect, it exceeded a real card at phone width (107px) and padded out whichever row the Off card sat in — a visible gap under its neighbour. 100px sits under the shortest real card anywhere in the range (~103px, in the 2-column band just above 344px), so grid stretch levels the row as before and the floor only does any work when Off and New are alone in an empty library.

**The judgement call worth a second opinion:** correcting the aspect on a phone means a shorter preview — 38px where the squashed one was 52px. I think it reads better (right shape, tighter cards, more scenes per screen), but if not, the levers are the mobile grid's `minmax(150px, 1fr)` or the card's 10px padding — not a height clamp.

## Verification

Checked at 1280 / 900 / 700 / 375 / 320px: every preview measures 3.750; the live active card (`LedCanvas` over the WebSocket) and the cached filmstrip cards agree; picker tiles and editor stage untouched; no console errors. `vitest` 74/74 passes (CSS-only change, no component tests cover this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)