### PR TITLE
Let a single scene be exported from the editor

### DIFF
--- a/packages/server/test/scene-store.test.js
+++ b/packages/server/test/scene-store.test.js
@@ -92,6 +92,29 @@ test('importMerge replaces by id and appends new', () => {
     assert.strictEqual(store.scenes.length, 2);
 });
 
+test('importMerge accepts a single-scene export, adding a new id', () => {
+    const store = makeStore();
+    const before = store.scenes.length;
+    store.importMerge([
+        { id: 'aabbccdd', name: 'Imported solo', layers: [{ id: 'x1', effectType: 'solid', params: {} }] },
+    ]);
+    assert.strictEqual(store.scenes.length, before + 1);
+    assert.strictEqual(store.get('aabbccdd').name, 'Imported solo');
+});
+
+test('importMerge accepts a single-scene export, replacing an existing id in place', () => {
+    const store = makeStore();
+    const scene = store.create({ name: 'Old name', layers: [{ effectType: 'solid', params: {} }] });
+    const before = store.scenes.length;
+    store.importMerge([
+        { id: scene.id, name: 'Edited elsewhere', layers: [{ id: 'y1', effectType: 'wavelet', params: {} }] },
+    ]);
+    assert.strictEqual(store.scenes.length, before, 'replace must not add a scene');
+    const updated = store.get(scene.id);
+    assert.strictEqual(updated.name, 'Edited elsewhere');
+    assert.strictEqual(updated.layers[0].effectType, 'wavelet');
+});
+
 test('getPublic strips runtime fields', () => {
     const store = makeStore();
     const scene = store.create({ name: 'X', layers: [{ effectType: 'solid', params: {} }] });

--- a/packages/ui/src/components/editor/Editor.jsx
+++ b/packages/ui/src/components/editor/Editor.jsx
@@ -6,6 +6,7 @@ import LayerStack from './LayerStack';
 import ParamPanel from './ParamPanel';
 import EffectPicker from './EffectPicker';
 import { newId as newLayerId } from '../../lib/id';
+import { downloadJson, slugify } from '../../lib/downloadJson';
 
 export default function Editor({ sceneId, onClose }) {
   const scene = useStore((s) => s.sceneDetails[sceneId]);
@@ -123,6 +124,10 @@ export default function Editor({ sceneId, onClose }) {
     onClose();
   }
 
+  function handleExportScene() {
+    downloadJson({ version: 2, scenes: [scene] }, `lightpanel-scene-${slugify(scene.name)}.json`);
+  }
+
   async function handleDuplicateScene() {
     const copy = {
       name: `${scene.name} copy`,
@@ -145,6 +150,7 @@ export default function Editor({ sceneId, onClose }) {
           aria-label="Scene name"
         />
         <div className="editor-toolbar-right">
+          <button className="btn btn-ghost" onClick={handleExportScene}>Export</button>
           <button className="btn btn-ghost" onClick={handleDuplicateScene}>Duplicate</button>
           <button
             className={`btn btn-ghost btn-danger${confirmingDelete ? ' btn-danger-armed' : ''}`}

--- a/packages/ui/src/components/switcher/SceneGrid.jsx
+++ b/packages/ui/src/components/switcher/SceneGrid.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useStore } from '../../state/store';
 import { api } from '../../api/client';
+import { downloadJson } from '../../lib/downloadJson';
 import SceneCard from './SceneCard';
 import useSceneDrag from './useSceneDrag';
 
@@ -35,14 +36,8 @@ export default function SceneGrid({ onEdit }) {
 
   function handleExport() {
     api.exportScenes().then((data) => {
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
       const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      a.href = url;
-      a.download = `lightpanel-scenes-${ts}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadJson(data, `lightpanel-scenes-${ts}.json`);
     });
   }
 

--- a/packages/ui/src/lib/downloadJson.js
+++ b/packages/ui/src/lib/downloadJson.js
@@ -1,0 +1,20 @@
+// Triggers a browser download of a JSON payload. Shared by the bulk scene
+// export (SceneGrid) and the single-scene export (Editor) so the blob/anchor
+// dance only exists once.
+export function downloadJson(data, filename) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// Filesystem/URL-safe stand-in for a scene name in a filename.
+export function slugify(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'scene';
+}


### PR DESCRIPTION
## Summary
- Adds an **Export** button to the editor toolbar (beside Duplicate) that downloads the scene being edited as a `{version: 2, scenes: [...]}` envelope, matching the shape the switcher's bulk export already produces.
- The file re-imports cleanly through the switcher's existing Import button on both the same panel (replaces by id) and a fresh one (adds it) — no server changes needed.
- Extracted the blob/anchor download dance into `packages/ui/src/lib/downloadJson.js`, shared between the bulk export (`SceneGrid.jsx`) and this new single-scene export.
- Added server tests covering single-scene `importMerge` for both the add and replace-in-place cases.

Closes #27.

## Test plan
- [x] `packages/server`: `npm test` — 83/83 passing
- [x] `packages/ui`: `npm test` — 86/86 passing
- [x] Round-tripped a real single-scene envelope through the running dev server (`POST /api/scenes/import`) for both the add and replace cases, then cleaned up the test scene
- [x] Verified in the browser: clicked Export in the editor, captured the downloaded blob, and confirmed its contents are exactly `{version: 2, scenes: [<edited scene>]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)