### PR TITLE
Let a wavelet travel inward toward its source

### DIFF
--- a/API.md
+++ b/API.md
@@ -207,18 +207,21 @@ Returns `{ "virtual": true }` if the server is running without Fadecandy hardwar
 
 ## Wavelet parameters
 
-The `wavelet` effect renders one sinusoidal wave radiating from a point; stack several with the `add` blend for interference patterns.
+The `wavelet` effect renders one sinusoidal wave radiating from a point — or converging on it; stack several with the `add` blend for interference patterns.
 
-| Field    | Type    | Description |
-|----------|---------|-------------|
-| `color`  | string  | Hex colour, e.g. `"#ff6633"` |
-| `freq`   | number  | Oscillation speed (higher = faster) |
-| `lambda` | number  | Spatial wavelength (higher = wider waves) |
-| `delta`  | number  | Phase offset |
-| `x`      | number  | Wave origin X. The panel spans ±3.625; the editor pad reaches ±1000 at full zoom |
-| `y`      | number  | Wave origin Y. The panel spans ±0.875; the editor pad reaches ±639 at full zoom |
-| `min`    | number  | Minimum intensity (UI uses non-linear arctan slider mapping) |
-| `max`    | number  | Maximum intensity |
+| Field       | Type    | Description |
+|-------------|---------|-------------|
+| `color`     | string  | Hex colour, e.g. `"#ff6633"` |
+| `freq`      | number  | Oscillation speed (higher = faster) |
+| `lambda`    | number  | Spatial wavelength (higher = wider waves) |
+| `delta`     | number  | Phase offset |
+| `x`         | number  | Wave origin X. The panel spans ±3.625; the editor pad reaches ±1000 at full zoom |
+| `y`         | number  | Wave origin Y. The panel spans ±0.875; the editor pad reaches ±639 at full zoom |
+| `direction` | string  | `"outward"` (default) or `"inward"` — whether crests run from the origin or converge on it |
+| `min`       | number  | Minimum intensity (UI uses non-linear arctan slider mapping) |
+| `max`       | number  | Maximum intensity |
+
+`direction` is a toggle rather than a negative `freq` or `lambda` because both of those are log sliders, which cannot express a negative. A layer stored without it renders outward, as it always did.
 
 Nothing clamps `x`/`y` server-side, and the editor's numeric fields accept values beyond the pad's reach — only the drag handle is bounded.
 
@@ -236,7 +239,7 @@ The `planewave` effect is the far-field limit of `wavelet`: parallel wavefronts 
 | `min`    | number  | Minimum intensity |
 | `max`    | number  | Maximum intensity |
 
-A `wavelet` at distance `D` and a `planewave` at `angle = atan2(y, x) + 180` (waves move away from their source) render identically once `D` is large, because the `D/lambda` term the approximation drops is a constant phase offset that folds into `delta`. That identity is what the conversion in `engine/planewave-migrate.js` uses.
+An outward `wavelet` at distance `D` and a `planewave` at `angle = atan2(y, x) + 180` (waves move away from their source) render identically once `D` is large, because the `D/lambda` term the approximation drops is a constant phase offset that folds into `delta`. An inward one is the same identity with both signs flipped: the angle is the bearing *of* the source, and the dropped distance is a phase lag instead of a lead. That identity is what the conversion in `engine/planewave-migrate.js` uses.
 
 ## WebSocket pixel stream
 

--- a/packages/server/effects/wavelet.js
+++ b/packages/server/effects/wavelet.js
@@ -2,10 +2,17 @@
  * Wavelet effect — one instance is one wavelet (the old multi-wavelet sum
  * is now expressed as multiple layers with the "add" blend mode).
  *
- * The inner loop is ported verbatim from shader.js interactive_wave(),
- * including the dz = pz + y sign quirk, so migrated presets render
- * identically. Output is clamped per-layer to [0, 255], matching the old
- * clip:true behaviour that every UI-created wavelet had.
+ * The inner loop comes from shader.js interactive_wave(), including the
+ * dz = pz + y sign quirk, so migrated presets render identically. Output is
+ * clamped per-layer to [0, 255], matching the old clip:true behaviour that
+ * every UI-created wavelet had.
+ *
+ * `direction` is the whole of the inward/outward toggle: the phase is
+ * theta = wt - r/lambda, and a crest is a point of constant theta, so as t
+ * grows r must grow with it — the crests run away from the source. Negating
+ * the radial term makes r shrink instead and the same wave converges on the
+ * source. It is a toggle rather than a negative freq or lambda because both
+ * of those are log sliders, which cannot express a negative at all.
  */
 
 var color = require('../engine/color');
@@ -30,6 +37,12 @@ module.exports = {
         { type: 'xy', label: 'Position', xKey: 'x', yKey: 'y',
           xRange: [-panel.HALF_X, panel.HALF_X], yRange: [-panel.HALF_Z, panel.HALF_Z],
           margin: 2, farLimit: 1000 },
+        // Labelled to match planewave's `angle`, which is also the direction
+        // the wave travels — the two effects should read the same way.
+        { key: 'direction', type: 'enum', label: 'Travel', options: [
+            { value: 'outward', label: 'Outward' },
+            { value: 'inward', label: 'Inward' },
+        ]},
         { type: 'range', label: 'Brightness', minKey: 'min', maxKey: 'max', scale: 'atan', modulatable: true },
     ],
     defaults: {
@@ -39,19 +52,26 @@ module.exports = {
         delta: 0.0,
         x: 0,
         y: 0,
+        direction: 'outward',
         min: 0.1,
         max: 0.7,
     },
 
     prepare(params) {
         var rgb = color.hexToRgb(params.color);
+        // 1/lambda with the travel direction's sign baked in, so the render
+        // loop is a multiply and neither branches nor divides. Anything but
+        // 'inward' reads as outward, which is what gives a layer stored before
+        // the toggle existed its old behaviour.
+        //
+        // A lambda of 0 would divide to Infinity and put NaN in the pixel
+        // buffer and out through setPixel; the slider can't reach 0, but the
+        // typed field is deliberately unclamped.
+        var k = (params.direction === 'inward' ? -1 : 1) / (params.lambda || MIN_LAMBDA);
         return {
             r: rgb.r, g: rgb.g, b: rgb.b,
             freq: params.freq,
-            // The render loop divides by lambda, so 0 would put NaN into the
-            // pixel buffer and out through setPixel. The slider can't reach 0,
-            // but the typed field is deliberately unclamped.
-            lambda: params.lambda || MIN_LAMBDA,
+            k: k,
             delta: params.delta,
             x: params.x,
             y: params.y,
@@ -67,12 +87,13 @@ module.exports = {
 
         return {
             render(out, millis, p) {
+                var phase = millis * 0.00628 * p.freq + p.delta;
                 for (var i = 0; i < n; i++) {
                     var dx = modelX[i] - p.x;
                     var dz = modelZ[i] + p.y;
                     var r = Math.sqrt(dx * dx + dz * dz);
-                    var theta = millis * 0.00628 * p.freq - r / p.lambda;
-                    var brightness = p.min + (p.max - p.min) * 0.5 * (Math.sin(theta + p.delta) + 1);
+                    var theta = phase - r * p.k;
+                    var brightness = p.min + (p.max - p.min) * 0.5 * (Math.sin(theta) + 1);
 
                     var wr = p.r * brightness;
                     var wg = p.g * brightness;

--- a/packages/server/engine/planewave-migrate.js
+++ b/packages/server/engine/planewave-migrate.js
@@ -47,16 +47,22 @@ function wrap(radians) {
 
 function waveletToPlanewave(params) {
     var distance = Math.sqrt(params.x * params.x + params.y * params.y);
-    // planewave's angle is the direction of travel, and a wave moves *away*
-    // from its source — so it is the bearing of the source plus 180.
-    var degrees = Math.atan2(params.y, params.x) * 180 / Math.PI + 180;
+    // An inward wavelet travels the other way, which flips both halves of the
+    // identity: the travel direction becomes the bearing *of* the source, and
+    // the dropped distance is a phase lag rather than a lead. No stored preset
+    // can be inward — the toggle postdates them all — but the conversion is
+    // exported, so keep it true for whatever is handed to it.
+    var inward = params.direction === 'inward';
+    // planewave's angle is the direction of travel, and an outward wave moves
+    // *away* from its source — so it is the bearing of the source plus 180.
+    var degrees = Math.atan2(params.y, params.x) * 180 / Math.PI + (inward ? 0 : 180);
     return {
         color: params.color,
         freq: params.freq,
         lambda: params.lambda,
-        // The source's distance is a fixed phase lead; drop the distance, keep
-        // the phase, and the panel sees exactly the same wave.
-        delta: wrap(params.delta - distance / params.lambda),
+        // The source's distance is a fixed phase offset; drop the distance,
+        // keep the phase, and the panel sees exactly the same wave.
+        delta: wrap(params.delta + (inward ? 1 : -1) * distance / params.lambda),
         angle: ((degrees % 360) + 360) % 360,
         min: params.min,
         max: params.max,

--- a/packages/server/test/effects.test.js
+++ b/packages/server/test/effects.test.js
@@ -50,6 +50,48 @@ test('wavelet render clamps output to [0, 255]', () => {
     assert.ok(out.every(v => v >= 0 && v <= 255));
 });
 
+test('wavelet crests run outward by default and inward when asked', () => {
+    // A row of pixels running away from a source at the origin, so a pixel's
+    // model x is exactly its distance from the source. lambda is wide enough
+    // that under two radians of phase fit across the row, so there is never
+    // more than one crest in view to confuse "which way did it move".
+    const n = 16;
+    const row = { numPixels: n, modelX: new Float32Array(n), modelZ: new Float32Array(n) };
+    for (let i = 0; i < n; i++) row.modelX[i] = 0.25 + i * 0.25;
+
+    const freq = 0.2;
+    const lambda = 2;
+    const instance = wavelet.createInstance(row);
+    const out = new Float32Array(n * 3);
+    // Times are quoted as the wave's own phase (wt), which is what puts the
+    // crest somewhere legible; millis is just the inverse of the render loop's
+    // wt = millis * 0.00628 * freq.
+    const crestAt = (direction, wt) => {
+        instance.render(out, wt / (0.00628 * freq), wavelet.prepare({
+            ...wavelet.defaults, color: '#ffffff', x: 0, y: 0,
+            freq, lambda, delta: 0, min: 0, max: 1, direction,
+        }));
+        let best = -1, bi = -1;
+        for (let i = 0; i < n; i++) if (out[i * 3] > best) { best = out[i * 3]; bi = i; }
+        // An off-the-end "crest" is the row's edge, not the wave's peak, and
+        // would make the comparison below meaningless.
+        assert.ok(bi > 0 && bi < n - 1, `crest sits on the row's edge at wt=${wt}`);
+        return row.modelX[bi];
+    };
+
+    assert.ok(crestAt('outward', 2.6) > crestAt('outward', 1.8),
+        'an outward crest must move away from the source');
+    assert.ok(crestAt('inward', 1.0) < crestAt('inward', 0.2),
+        'an inward crest must converge on the source');
+});
+
+test('a wavelet stored before the direction toggle renders as outward', () => {
+    const stored = { ...wavelet.defaults, color: '#ffffff' };
+    delete stored.direction;
+    assert.strictEqual(wavelet.prepare(stored).k, wavelet.prepare({ ...stored, direction: 'outward' }).k);
+    assert.ok(wavelet.prepare(stored).k > 0, 'outward subtracts the radial term');
+});
+
 test('planewave prepare bakes the direction into cos/sin', () => {
     const p = planewave.prepare({ ...planewave.defaults, angle: 90 });
     assert.ok(Math.abs(p.ca - 0) < 1e-12);

--- a/packages/server/test/planewave-migrate.test.js
+++ b/packages/server/test/planewave-migrate.test.js
@@ -133,6 +133,24 @@ test('angle is the direction of travel, opposite the source bearing', () => {
     assert.ok(Math.abs(at(0, -1000) - 90) < 1e-9, 'results wrap into 0-360');
 });
 
+test('an inward wavelet converts to a plane wave travelling the other way', () => {
+    // No stored preset can be inward — the toggle postdates them all — but the
+    // identity the conversion rests on flips with the travel direction, and
+    // waveletToPlanewave is exported for anything that comes later.
+    const base = { color: '#ffffff', freq: 0.2, lambda: 1, delta: 0, x: 1000, y: 500, min: 0.1, max: 0.7 };
+    const outward = planewave.waveletToPlanewave(base);
+    const inward = planewave.waveletToPlanewave({ ...base, direction: 'inward' });
+
+    const apart = Math.abs(((inward.angle - outward.angle) % 360 + 360) % 360 - 180);
+    assert.ok(apart < 1e-9, `angles ${inward.angle} and ${outward.angle} should be 180 apart`);
+
+    // And the converted wave still matches the wavelet it came from.
+    for (const millis of [0, 1234, 60000]) {
+        const worst = renderBoth({ ...base, direction: 'inward' }, millis);
+        assert.ok(worst < 1, `channel error ${worst.toFixed(3)} at millis=${millis}`);
+    }
+});
+
 test('crests advance along the angle, not against it', () => {
     // The bug this guards: the dial pointed one way and the animation ran the
     // other. Track a crest's position over time and check it moves with the

--- a/packages/ui/src/components/controls/CLAUDE.md
+++ b/packages/ui/src/components/controls/CLAUDE.md
@@ -16,4 +16,4 @@ The two **end** colours (first/last by position, so a stop dragged past an end s
 
 ## `AngleDial.jsx`
 
-Draws the wavefronts, not just a knob. Its arrow points the way the wave **travels**, so the control agrees with the motion — note that is the opposite of where an equivalent wavelet's source sits.
+Draws the wavefronts, not just a knob. Its arrow points the way the wave **travels**, so the control agrees with the motion — note that is the opposite of where an equivalent *outward* wavelet's source sits. Wavelet's own inward/outward toggle carries the same `Travel` label for that reason: both effects label the direction the wave goes, not where it comes from.


### PR DESCRIPTION
Closes #12.

A wavelet's crests could only run away from its source. This adds a `direction` param — a plain **Outward / Inward** toggle — so the same wave can converge on its origin.

## Why a toggle rather than a negative number

`freq` and `lambda` are both `scale: 'log'` sliders, and a log scale cannot express a negative at all. Overloading either one would mean a control only typing could reach, so the direction is its own schema entry as the issue proposed.

## What changed

**`effects/wavelet.js`** — new `direction` enum, defaulting to `outward`, sitting just after the position pad. `prepare()` bakes the sign into `1/lambda` as a single `k`, so the render loop went from `- r / p.lambda` to `- r * p.k`: a multiply instead of a divide, and no branch in the hot loop. The loop-invariant time term is hoisted out the way planewave already does it. Anything that isn't the string `'inward'` reads as outward, so every stored layer keeps the look it has today — `normaliseLayer` merges the new default in on load, and layers written before this change simply don't carry the key.

**No UI changes.** ParamPanel already walks the schema and renders `enum` entries as segmented buttons, so the control came for free.

**Naming.** The issue asked whether the two wave effects should read consistently. They do now: the toggle carries planewave's `Travel` label, so both effects name *the direction the wave goes*, not where it comes from. `controls/CLAUDE.md` notes the pairing beside AngleDial's existing remark.

**`engine/planewave-migrate.js`** — the far-field identity flips with the travel direction: an inward wavelet's equivalent plane wave points along the bearing *of* the source (not +180), and the dropped distance becomes a phase lag rather than a lead. No stored preset can be inward, since the toggle postdates them all, but `waveletToPlanewave` is exported and tested, so it shouldn't hold a latent wrong answer.

**`API.md`** — the new field, the toggle-vs-negative-number rationale, and the inward half of the wavelet↔planewave identity.

## Testing

86 server tests and 86 UI tests pass. New coverage:

- **Crest tracking** on a row of pixels running away from the source — outward crests move away, inward crests converge. Times are quoted as the wave's own phase so the crest lands somewhere legible, `lambda` is wide enough that under two radians fit across the row (never more than one crest to confuse "which way did it move"), and the helper asserts the crest isn't sitting on the row's edge, which would make the comparison meaningless.
- **Back-compat**: a layer stored without `direction` prepares to exactly the same `k` as an explicit `outward`.
- **Migration**: an inward distant wavelet converts 180° from the outward one and still renders within one channel of the wavelet it came from.

Also driven in the real editor: the `Travel` row renders between Position and Brightness, clicking **Inward** re-rendered the panel and the layer thumbnail, `GET /api/scenes/:id` came back with `direction: inward`, and there were no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)