### PR TITLE
Let the emitter's Density reach the whole particle pool

### DIFF
--- a/packages/server/effects/emitter.js
+++ b/packages/server/effects/emitter.js
@@ -35,6 +35,16 @@ var color = require('../engine/color');
 var particles = require('../engine/particles');
 var panel = require('../engine/panel');
 
+// The pool size and the top of the Density slider, which are the same number:
+// every slot is a particle the emitter can spawn into, pool[0..count-1]. The
+// sibling particle_trail stops one short of its pool because pool[0] is its
+// head and the trail hangs off it; there is no head here, so a -1 copied from
+// there would only shorten the slider. Note the schema max is a real cap and
+// not merely a slider hint — prepare() clamps to it, so the unclamped typed
+// field cannot reach past the pool either. What binds the constant is render
+// cost: engine/particles walks 240 pixels per particle, linear in this, and a
+// scene can stack several emitter layers into one 10ms tick. It is deliberately
+// not derived from the panel's pixel count for that reason.
 var MAX_PARTICLES = 80;
 
 // The panel is 30x8 on a square pitch, so it is 4.1x wider than it is tall.
@@ -97,7 +107,7 @@ module.exports = {
         { key: 'extY', type: 'number', label: 'Height', min: 0, max: MAX_EXT_Y, step: 0.05, scale: 'linear', modulatable: true },
 
         { type: 'group', label: 'Emission' },
-        { key: 'count', type: 'number', label: 'Density', min: 1, max: MAX_PARTICLES - 1, step: 1, scale: 'linear', modulatable: true },
+        { key: 'count', type: 'number', label: 'Density', min: 1, max: MAX_PARTICLES, step: 1, scale: 'linear', modulatable: true },
         // How many and how big sit together: they are the two knobs you trade
         // against each other to fill the panel. A radius in world units — the
         // LED pitch is 0.25, so 0.25 is one LED across. Log because 1/size^2
@@ -190,7 +200,7 @@ module.exports = {
             speedSpread: params.speedSpread,
             ax: params.grav * Math.cos(ga) * X_STRETCH,
             az: params.grav * Math.sin(ga),
-            count: Math.min(MAX_PARTICLES - 1, Math.max(1, params.count | 0)),
+            count: Math.min(MAX_PARTICLES, Math.max(1, params.count | 0)),
             // Seconds in, milliseconds out — the render loop works in millis.
             life: params.life * 1000,
             lifeSpread: params.lifeSpread,

--- a/packages/server/effects/particle-trail.js
+++ b/packages/server/effects/particle-trail.js
@@ -7,6 +7,10 @@
 var color = require('../engine/color');
 var particles = require('../engine/particles');
 
+// The pool size. The count stops one short of it throughout because pool[0] is
+// the head particle and the trail fills pool[1..count], so the render below
+// hands over count + 1 slots. The -1 is that head, not a fencepost to tidy
+// away: emitter.js has no head and deliberately does not carry one.
 var MAX_PARTICLES = 80;
 
 module.exports = {

--- a/packages/server/test/particles.test.js
+++ b/packages/server/test/particles.test.js
@@ -74,6 +74,24 @@ test('param changes do not reset particle state', () => {
     assert.ok(out.every(v => Number.isFinite(v)));
 });
 
+// The emitter has no head particle, so its Density reaches every slot in the
+// pool — the -1 that particle_trail needs for pool[0] would only shorten the
+// slider here. The cap is enforced in prepare(), not just hinted at by the
+// schema, because the typed field beside the slider is deliberately unclamped.
+test('the emitter clamps Density to its schema max, and that is the whole pool', () => {
+    const emitter = effects.get('emitter');
+    const max = emitter.schema.find(s => s.key === 'count').max;
+    assert.strictEqual(emitter.prepare({ ...emitter.defaults, count: 1e6 }).count, max);
+
+    // Every one of those slots must be reachable: renderParticles walks
+    // pool[0..count-1], so a count past the pool reads undefined and throws.
+    const instance = emitter.createInstance(ctx);
+    const prepared = emitter.prepare({ ...emitter.defaults, count: max, life: 0.5 });
+    const out = new Float32Array(ctx.numPixels * 3);
+    for (let t = 0; t < 4000; t += 100) instance.render(out, t, prepared);
+    assert.ok(out.some(v => v > 0));
+});
+
 test('particle effects render without allocation errors at max density', () => {
     for (const type of ['emitter', 'particle_trail']) {
         const mod = effects.get(type);


### PR DESCRIPTION
Closes #46.

## What changed

The emitter's Density slider ran 1–79 against a pool of 80. The `- 1` was inherited from `particle-trail.js`, where it is load-bearing — `pool[0]` is the head particle and the trail hangs off it, so the render call passes `numParticles + 1`. The emitter has no head: it fills `pool[0..count-1]` and renders exactly that many slots, so the `- 1` was only shortening the slider and leaving an arbitrary-looking number at the top of it.

- `packages/server/effects/emitter.js` — schema `max: MAX_PARTICLES` and `prepare()` clamps to `Math.min(MAX_PARTICLES, …)`. **Both had to move together**: the clamp is a real cap, not a slider hint, so the deliberately-unclamped typed field could not reach 80 either.
- Comments at both `MAX_PARTICLES` constants, recording why the emitter uses its whole pool and why `particle-trail`'s `- 1` is the head slot and stays.
- `packages/server/test/particles.test.js` — a test pinning that `prepare()` clamps to the schema max and that every slot up to it renders. A `- 1` creeping back fails it; a cap past the pool throws on `pool[80]`, which I confirmed by hand while benchmarking.

Nothing needs migrating: every stored `count` is ≤ 79 and stays valid, and the pool is allocated once per instance, not per frame. The ramp is unchanged — `cadence` is `life / count`, so a denser emitter still fills at count/life births per second.

## MAX_PARTICLES stays 80

The issue floated 100, conditional on a clean frame-rate reading from the Pi. Measured locally (full `render()` per frame, 240 px, defaults, 20k frames after warm-up):

| Density | ms/frame (dev Mac) | share of the 10ms tick |
|---|---|---|
| 79 | 0.295 | 2.9% |
| 80 | 0.296 | 3.0% |
| 100 | 0.372 | 3.7% |
| 128 | 0.468 | 4.7% |

Linear in the count, and 79 → 100 is +26%, matching the issue's estimate. The absolute numbers came out ~2× the issue's table (different measurement scope), which is the reason not to lean on them: at 3.7% of a tick per layer here, a Pi at even 3–4× with several emitter layers stacked is a real slice of 10ms. That check needs the Pi's own `/api/fps` late-frame rate against a deliberately heavy multi-emitter scene, and it has not been run — so this PR takes the clean 80 the issue names as the fallback. Raising it later is one constant; the slider follows automatically.

`particle-trail.js` is otherwise untouched, as the issue asks.

## Testing

- `packages/server`: 179 tests pass (178 before, +1 new).
- `packages/ui`: 121 tests pass — no UI change was needed, since ParamPanel reads `max` from the served schema.
- Verified the served catalog directly: emitter Density `max` is 80 and `prepare({count: 80}).count === 80`, while `particle_trail` still clamps to 79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)