### PR TITLE
Re-resolve text tokens when the string itself changes

### DIFF
--- a/packages/server/effects/text.js
+++ b/packages/server/effects/text.js
@@ -163,17 +163,30 @@ module.exports = {
         var mask = null;
         var resolved = '';
         var resolvedAt = null;
+        var resolvedFrom = null;
 
         return {
             render(out, millis, p) {
-                if (p.tokenMs === 0) {
-                    resolved = p.text;
-                } else {
-                    var bucket = Math.floor(millis / p.tokenMs);
-                    if (bucket !== resolvedAt) {
-                        resolved = raster.resolveTokens(p.text, millis);
-                        resolvedAt = bucket;
-                    }
+                // The resolution cache is keyed on the *source* string as well
+                // as the clock bucket, and both halves are load-bearing. The
+                // bucket alone is what a clock needs — {ss} re-resolves once a
+                // second and {HH} once a minute — but it makes the source
+                // string invisible to the cache, so a keystroke landing inside
+                // the bucket a token last resolved in never re-resolves and the
+                // layer keeps rendering the old line. tokenPeriod() is a minute
+                // for every token but {ss}/{s}, so that is up to 60s of typing
+                // into a panel that does not change and then catches up all at
+                // once, which reads as a flaky layer rather than a stale cache.
+                // The source string alone is not enough either: it is the same
+                // string every frame while a clock ticks. Note the bucket has to
+                // be reset on the token-free path too — otherwise removing a
+                // token and putting it back inside one minute leaves a stale
+                // bucket matching, and the layer renders neither string.
+                var bucket = p.tokenMs === 0 ? 0 : Math.floor(millis / p.tokenMs);
+                if (bucket !== resolvedAt || p.text !== resolvedFrom) {
+                    resolved = p.tokenMs === 0 ? p.text : raster.resolveTokens(p.text, millis);
+                    resolvedAt = bucket;
+                    resolvedFrom = p.text;
                 }
                 var key = p.font + '|' + p.tracking + '|' + resolved;
                 if (key !== maskKey) {

--- a/packages/server/test/effects.test.js
+++ b/packages/server/test/effects.test.js
@@ -902,6 +902,56 @@ test('static text allocates no new mask once it is laid out', () => {
     assert.notDeepStrictEqual(Array.from(out), first, 'a changed string must rebuild the mask');
 });
 
+// The regression the resolution cache's source-string key defends against.
+// Keying it on the clock bucket alone made an edit invisible for as long as the
+// bucket lasted — a minute for every token but {ss}/{s} — so the layer sat on
+// the line it resolved first while the text kept being typed, then caught up in
+// one jump when the minute rolled over.
+test('an edit to a string holding a clock token takes effect immediately', () => {
+    const ctx = panelCtx();
+    const instance = text.createInstance(ctx);
+    const out = new Float32Array(ctx.numPixels * 3);
+    const at = new Date(2026, 7, 17, 10, 15, 0).getTime();
+    const render = (s, millis) => {
+        instance.render(out, millis, text.prepare({ ...text.defaults, text: s, softness: 0 }));
+        return Array.from(out);
+    };
+
+    // {DD} is a minute-period token, so all three renders share one bucket.
+    const day = render('{DD}', at);
+    assert.notDeepStrictEqual(render('{DD} X', at + 50), day,
+        'a keystroke inside the token period must re-resolve');
+    assert.notDeepStrictEqual(render('{DD} XYZ', at + 100), day);
+
+    // And the resolved value is still the right one, not merely a different
+    // one: it must match what a fresh instance renders for the same string.
+    const fresh = new Float32Array(ctx.numPixels * 3);
+    text.createInstance(ctx).render(fresh,
+        at + 100, text.prepare({ ...text.defaults, text: '{DD} XYZ', softness: 0 }));
+    assert.deepStrictEqual(render('{DD} XYZ', at + 100), Array.from(fresh));
+});
+
+// The nastier half of the same bug: the token-free path used to leave the bucket
+// behind, so a token removed and put back inside one minute matched a stale
+// bucket and the layer rendered the string in between — not a prefix of what was
+// typed, but arbitrary earlier content.
+test('a clock token removed and restored inside its period still re-resolves', () => {
+    const ctx = panelCtx();
+    const instance = text.createInstance(ctx);
+    const out = new Float32Array(ctx.numPixels * 3);
+    const at = new Date(2026, 7, 17, 10, 15, 0).getTime();
+    const render = (s, millis) => {
+        instance.render(out, millis, text.prepare({ ...text.defaults, text: s, softness: 0 }));
+        return Array.from(out);
+    };
+
+    const clock = render('{HH}', at);
+    const plain = render('HELLO', at + 50);
+    assert.notDeepStrictEqual(plain, clock);
+    assert.deepStrictEqual(render('{HH}', at + 100), clock,
+        'restoring the token must render the clock again, not the string it replaced');
+});
+
 // The compatibility guarantee for every layer already stored: the background
 // lerp has to reduce to exactly what scaling the ink alone used to produce.
 test('a black background renders identically to scaling the ink alone', () => {


### PR DESCRIPTION
Fixes #55.

## The bug

`effects/text.js` cached its resolved string against the clock bucket alone:

```js
var bucket = Math.floor(millis / p.tokenMs);
if (bucket !== resolvedAt) { resolved = raster.resolveTokens(p.text, millis); resolvedAt = bucket; }
```

That makes the *source* string invisible to the cache. A keystroke landing inside the bucket a token last resolved in never re-resolved, and since the mask key downstream is built from `resolved`, the mask wasn't rebuilt either — so the layer went on rendering the line it first laid out. `raster.tokenPeriod()` is `60000` for every token but `{ss}`/`{s}`, so typing after a `{DD}` left the panel unchanged for up to a minute and then caught up in one jump. Reads as a flaky layer rather than a stale cache, which is why it was reported as unreliable rather than broken.

## The fix

Key the cache on the source string as well as the bucket. Both halves are load-bearing — the string alone is the same every frame while a clock ticks, and the bucket alone is what this bug was.

The token-free path now resets the bucket too, which fixes the nastier half of the same defect: `resolvedAt` used to survive a text that stopped containing a token, so removing one and putting it back inside a minute matched a stale bucket and left the layer rendering *the string in between* — arbitrary earlier content rather than a prefix of what was typed. Before this change, `{HH}` → `HELLO` → `{HH}` inside one minute ended up drawing "HELLO".

Still allocation-free on the per-frame path: a string comparison against the prepared param, nothing new per tick.

## Tests

Two added to `test/effects.test.js`, both confirmed failing on the parent commit and passing here (`# pass 179 / # fail 2` before, `# pass 181 / # fail 0` after):

- `an edit to a string holding a clock token takes effect immediately` — three renders sharing one `{DD}` bucket must differ, *and* the last must match what a fresh instance renders for the same string, so it can't pass on merely being different.
- `a clock token removed and restored inside its period still re-resolves` — the restored `{HH}` must render the clock again, not the string that replaced it.

Full server suite green (181 tests). No UI change: `TextControl` already writes through on every keystroke and `prepare()` already received the right string — the staleness was entirely inside the render instance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhDKC6JYYtewgSa9nnGi5b)_