### PR TITLE
Update docs for blinky's move off Node 14/Buster to Node 24/Trixie

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ npm run dev            # alias for VIRTUAL=1 node app.js
 npm test               # node:test suite (node --test)
 ```
 
-The deployed Raspberry Pi runs **Node 14** (`lightpanel.service`) — keep server runtime code to ES2019 (no `?.`/`??` in `packages/server/` outside tests).
+The deployed Raspberry Pi runs **Node 24** on Raspberry Pi OS (Debian 13/Trixie, 64-bit) via `lightpanel.service`, reprovisioned from the old Node 14/Buster setup in 2026-08 — server runtime code is no longer restricted to ES2019.
 
 ## Server Architecture (`packages/server/`)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you don't have the hardware, the server can run in **virtual mode** (`VIRTUAL
 
 ## Prerequisites
 
-- Node.js 16+ (14 is supported but 16+ recommended)
+- Node.js 18+ (the deployed Pi runs Node 24; the old Node 14 constraint no longer applies)
 - npm 7+ (for workspace support)
 
 For hardware mode only:

--- a/packages/server/engine/frame-stats.js
+++ b/packages/server/engine/frame-stats.js
@@ -30,8 +30,6 @@
  * stumbling now, and it is the one worth watching: a running total only ever
  * climbs, so one coalesced tick at start-up reads the same as a scene that is
  * genuinely too expensive. Both are scoped to the active scene; see restart().
- *
- * Node 14 on the Pi: ES2019 only, no ?. or ?? in here.
  */
 
 var performance = require('perf_hooks').performance;

--- a/packages/server/engine/power.js
+++ b/packages/server/engine/power.js
@@ -35,8 +35,6 @@
  *   k = s^(1/gamma). WLED's linear rescale would over-dim hard here: needing
  *   66% of the current means k = 0.845 (white at byte ~215), where a linear
  *   factor would drop it to ~168.
- *
- * Node 14 on the Pi: ES2019 only, no ?. or ?? in here.
  */
 
 // Same line frame-stats draws for "nothing has rendered lately". It is the

--- a/packages/server/fcserver.service
+++ b/packages/server/fcserver.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Fadecandy Server
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi
+ExecStart=/usr/local/bin/fcserver /usr/local/bin/fcserver.json
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/server/lightpanel.service
+++ b/packages/server/lightpanel.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=NeoPixel Light Panel
-After=network.target
+After=network.target fcserver.service
 
 [Service]
 Type=simple
 User=pi
 WorkingDirectory=/home/pi/github/neopixel-light-panel/packages/server
-ExecStart=/home/pi/.nvm/versions/node/v14.21.3/bin/node app.js
+ExecStart=/home/pi/.nvm/versions/node/v24.20.0/bin/node app.js
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- blinky was reflashed from Raspbian Buster (Debian 10, EOL, 32-bit) to Raspberry Pi OS Trixie (Debian 13, 64-bit), and now runs Node 24 via nvm instead of the old Node 14 pin
- `packages/server` is no longer restricted to ES2019 (`?.`/`??` are fine now) — updated CLAUDE.md and dropped the stale comments in `frame-stats.js` and `power.js`
- `lightpanel.service` updated to the new Node 24 path and to wait on the new `fcserver.service`
- Checked in `fcserver.service` (new — `fcserver` now runs under systemd as `User=pi` with a udev rule for USB access, replacing the old root/`rc.local` setup)
- README prerequisites updated to match

## Test plan
- [x] Verified live on blinky: all four units (`fcserver`, `lightpanel`, `power-watch`, `power-monitor`) enabled and running on the new OS
- [x] Full `deploy` skill flow (`npm run deploy` → `git pull` → `systemctl restart lightpanel`) run end-to-end passwordlessly and confirmed working
- [x] Panel visually confirmed lit by the user