### PR TITLE
Fix Vite CJS Node API deprecation warning in UI tests

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,7 @@
   "name": "neopixel-light-panel-ui",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "react": "^18.3.1",
     "react-colorful": "^5.6.1",


### PR DESCRIPTION
## Summary
- `packages/ui/package.json` had no `"type"` field, so vitest resolved Vite's Node API through its deprecated CJS entry point, printing `The CJS build of Vite's Node API is deprecated...` on every test run (introduced alongside CI in #61)
- Added `"type": "module"` — the package already uses `import`/`export` exclusively, no `require()`/`module.exports` anywhere, so this is a no-op behaviorally

## Test plan
- [x] `cd packages/ui && CI=true npx vitest run` — warning gone, all 127 tests still pass
- [x] `npm run build --workspace=packages/ui` — production build succeeds
- [x] `npx vite` dev server still boots correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)