### PR TITLE
Test the Pi's install path in CI, on the Pi's architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [master]
 
 jobs:
+  # Fast signal: replays the lockfile verbatim and runs the suites.
   test:
     runs-on: ubuntu-latest
     steps:
@@ -22,5 +23,59 @@ jobs:
       - run: npm test --workspace=packages/server
 
       - run: npm test --workspace=packages/ui
+
+      - run: npm run build --workspace=packages/ui
+
+  # What `test` cannot answer. It runs `npm ci` on linux-x64; the Pi runs
+  # `npm install` on linux-arm64 (scripts/deploy-pi.sh). Those differ in both
+  # axes that have bitten:
+  #
+  #   - `npm ci` replays a lockfile verbatim, `npm install` re-resolves it. A
+  #     lockfile that is internally inconsistent passes `npm ci` and can still
+  #     change shape on the Pi — the state Dependabot's #70 would have merged.
+  #   - native binaries are per-platform, so nothing about rolldown/oxc or
+  #     lightningcss on aarch64 (#81) is visible from an x64 job at all.
+  #
+  # arm64 runners are free for public repos, so mirroring the deploy path costs
+  # one job. Ubuntu 24.04 is glibc 2.39 against the Pi's Debian 13 / glibc 2.41
+  # — the conservative direction, since a binary that links here also links
+  # there. Close, not identical: this is a pre-deploy signal, not a substitute
+  # for `npm run deploy`.
+  pi-path:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      # Node 24 bundles npm 11.x, as the Pi runs (11.19.0) — so the allowScripts
+      # policy that leaves esbuild's postinstall unrun applies in both places.
+      - run: npm install --no-audit --no-fund
+
+      - name: Lockfile must survive a re-resolve
+        run: |
+          if ! git diff --quiet -- package-lock.json; then
+            echo "::error file=package-lock.json::npm install re-resolved the lockfile. It is committed in a state npm does not agree with, so the Pi would install a different tree than CI tested. Run 'npm install' locally and commit the result."
+            git diff --stat -- package-lock.json
+            git diff -- package-lock.json | head -100
+            exit 1
+          fi
+          echo "Lockfile unchanged by npm install."
+
+      # #78 installed three copies of vite and went green; npm ci had no reason
+      # to complain, and nothing else would have noticed.
+      - name: Exactly one copy of vite
+        run: |
+          copies=$(find . -type d -path '*/node_modules/vite' | sort)
+          n=$(printf '%s' "$copies" | grep -c '^' || true)
+          if [ "$n" -ne 1 ]; then
+            echo "::error::expected exactly one node_modules/vite, found $n:"
+            printf '%s\n' "$copies"
+            exit 1
+          fi
+          printf 'One copy of vite: %s\n' "$copies"
 
       - run: npm run build --workspace=packages/ui


### PR DESCRIPTION
Addresses **gap 3 of #83** — "CI's install and platform don't match the Pi's". Does not close the issue; gaps 1 (HTTP-level route coverage) and 2 (UI render smoke tests) are untouched.

## The mismatch

| | old `test` job | Pi (`scripts/deploy-pi.sh`) | new `pi-path` job |
|---|---|---|---|
| command | `npm ci` | `npm install` | `npm install` |
| platform | linux-x64 | linux-arm64 (Debian 13) | linux-arm64 (Ubuntu 24.04) |
| npm | bundled with setup-node | 11.19.0 | bundled (11.x) |

Both axes have already cost a triage round:

- **`npm ci` replays a lockfile verbatim; `npm install` re-resolves it.** A lockfile that is internally inconsistent passes `npm ci` and still changes shape on the Pi — exactly the state Dependabot's #70 would have merged. The new job fails on any diff to `package-lock.json` after an install.
- **Native binaries are per-platform.** An x64 job cannot see whether rolldown/oxc or lightningcss resolve on aarch64, which is the question #81 is blocked on. arm64 runners are free for public repos, so the job runs the Pi's build on `ubuntu-24.04-arm`.

It also asserts **exactly one `node_modules/vite`**. #78 installed three copies and went green — `npm ci` had no reason to object and nothing else was looking. That is #81's stated acceptance criterion, now mechanised.

## What this is not

`ubuntu-24.04-arm` is glibc 2.39; the Pi is Debian 13 at glibc 2.41. That is the conservative direction — a binary that links against the older one links against the newer — so a pass here is good evidence, not proof. **This is a pre-deploy signal, not a substitute for `npm run deploy`.** #81's acceptance still requires a real deploy to blinky.

The job deliberately does not run the test suites; the x64 job covers those, and the point here is the install and build path.

## Verification

Before writing the assertions, checked that they pass on master rather than landing red — a clean `git clone` plus `npm install`:

- leaves `package-lock.json` **untouched**
- yields **one** deduped copy of vite (`npm ls vite --all` confirms `@vitejs/plugin-react`, `vitest` and `@vitest/mocker` all dedupe to the single `vite@6.4.3`)
- reproduces the Pi's npm 11 `allowScripts` warning for `esbuild`'s unrun postinstall, confirming the policy match

Also unit-tested the counting logic for 0, 1 and 3 copies, and validated the workflow YAML parses with both jobs and the expected steps.

Both jobs should be green on this PR — the arm64 half is itself the first real check that the current vite 6 tree builds on aarch64 in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtwuATkj9zxg42vi8VWBY5