### PR TITLE
Scale twinkle's swell into the headroom above the backglow

### DIFF
--- a/packages/server/effects/twinkle.js
+++ b/packages/server/effects/twinkle.js
@@ -69,6 +69,15 @@ module.exports = {
             speed: params.speed,
             sharpness: params.sharpness,
             background: params.background,
+            // The swell is scaled into the headroom *above* the backglow
+            // rather than added on top of it, so a star at peak is exactly
+            // the configured colour for any backglow (issue #94). Added on
+            // top, the peak was 1 + background: at the default 0.02 only red
+            // clipped in the sink, so the brightest moment of a star was a
+            // desaturated version of the swatch. Clamped at 0 because typed
+            // entry is deliberately unclamped — a backglow past 1 is already
+            // over full, and nothing above it is left to swell into.
+            swell: Math.max(0, 1 - params.background),
         };
     },
 
@@ -94,7 +103,7 @@ module.exports = {
                         // Sharpen so pixels are dark most of the cycle.
                         // Math.pow is the price of a per-layer exponent,
                         // paid only on the lit pixels.
-                        if (s > 0) level += Math.pow(s, p.sharpness);
+                        if (s > 0) level += p.swell * Math.pow(s, p.sharpness);
                     }
 
                     var r = p.r, g = p.g, b = p.b;

--- a/packages/server/test/effects.test.js
+++ b/packages/server/test/effects.test.js
@@ -735,6 +735,35 @@ test('twinkle sharpness changes how much of the cycle is lit', () => {
     assert.ok(litSum(1) > litSum(12), 'sharpness must darken the duty cycle');
 });
 
+// The backglow is a floor the swell is scaled into, not a bias added on top of
+// it (issue #94). Added on top, the peak was 1 + background and the sink's
+// per-channel clamp bit red first, so the brightest moment of a star drifted
+// off the configured colour — worst exactly where it shows most.
+test('twinkle peaks at the configured colour for any backglow', () => {
+    const ctx = panelCtx();
+    const rgb = [255, 233, 196]; // #ffe9c4, the default swatch
+    for (const background of [0, 0.02, 0.1, 0.5]) {
+        // sharpness 1 is the plain sine, so a peak is reached often enough to
+        // catch within one sweep at every period in the instance's spread.
+        const p = twinkle.prepare({ ...twinkle.defaults, sharpness: 1, density: 1, background });
+        const inst = twinkle.createInstance(ctx);
+        const out = new Float32Array(ctx.numPixels * 3);
+        const peak = [0, 0, 0];
+        for (let f = 0; f < 400; f++) {
+            inst.render(out, f * 25, p);
+            for (let i = 0; i < ctx.numPixels; i++) {
+                for (let k = 0; k < 3; k++) peak[k] = Math.max(peak[k], out[i * 3 + k]);
+            }
+        }
+        for (let k = 0; k < 3; k++) {
+            assert.ok(peak[k] <= rgb[k] + 1e-4,
+                `background ${background} channel ${k} overshot: ${peak[k]} > ${rgb[k]}`);
+            assert.ok(peak[k] > rgb[k] - 0.5,
+                `background ${background} channel ${k} never reached the colour: ${peak[k]}`);
+        }
+    }
+});
+
 
 // The vertical axis inverts between param space (y up, what the pad and the
 // dials draw) and modelZ (+0.875 is the *bottom* row). Origin, travel and


### PR DESCRIPTION
Fixes #94.

`twinkle` built its level as `background + Math.pow(s, sharpness)`. The swell tops out at exactly 1, so the level peaked at `1 + background` — the backglow was a bias added *on top of* the peak instead of a floor the peak scales into, which made the effect's own `color` param unreachable. At the default `background: 0.02` the peak is 260.1/237.7/199.9 against a swatch of 255/233/196; only red clips in the sink, so the ratio shifts and a star reads slightly desaturated at its brightest moment. At the slider's maximum of 0.5 the peak is 1.5x.

## The change

- `prepare()` derives `swell: Math.max(0, 1 - params.background)` — the headroom above the floor — and `render()` uses `level += p.swell * Math.pow(s, p.sharpness)`. Peak level is exactly 1.0 for any backglow, so a peak channel is exactly the configured colour.
- Precomputed in `prepare` rather than inline: the hot loop pays a multiply instead of a subtract per pixel per frame.
- Clamped at 0 because typed entry is deliberately unclamped. A backglow past 1 is already over full and has nothing left to swell into; without the clamp the swell would start *subtracting* from the floor.

The dark end is unchanged. The visible change at defaults is the 2% reduction in peak brightness.

Not a move toward keeping effects in range — the compositor's accumulator is deliberately unbounded and `emitter` legitimately exceeds 255 by summing overlapping particles. This bug was specific to a param documented as a floor behaving as a bias.

## Test

`twinkle peaks at the configured colour for any backglow` sweeps `background` over `[0, 0.02, 0.1, 0.5]` (the slider maximum included), renders 400 frames, and asserts each channel's peak lands on the swatch — neither over nor short.

Verified by reintroducing the old arithmetic: it fails with `background 0.02 channel 0 overshot: 260.1000061035156 > 255` and every other test still passes. Full server suite is 232 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB8swscFp1iwvCeEwdxhL3