### PR TITLE
Point branch references at main instead of master

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -5,7 +5,7 @@ description: Deploy the light panel to the Raspberry Pi (blinky) — pulls, buil
 
 Deploy the light panel to the Pi (`blinky`). Run the steps below directly instead of re-deriving the process — this sequence has been rehearsed and verified end-to-end.
 
-The UI and server deploy the same way now: the Pi does `git pull` against `origin/master` and builds the UI itself (blinky moved off Node 14/Buster to Node 24/Trixie in 2026-08 — see `CLAUDE.md`). There's no Mac-side build or rsync step anymore, so nothing here can drift from what's on GitHub.
+The UI and server deploy the same way now: the Pi does `git pull` against `origin/main` and builds the UI itself (blinky moved off Node 14/Buster to Node 24/Trixie in 2026-08 — see `CLAUDE.md`). There's no Mac-side build or rsync step anymore, so nothing here can drift from what's on GitHub.
 
 ## 0. Bail out if not running from the CLI
 
@@ -19,7 +19,7 @@ If `CLAUDE_CODE_ENTRYPOINT=cli`, proceed.
 
 ## 1. Check local branch status
 
-The Pi builds only from `origin/master`, so anything not pushed and merged there simply won't deploy. Check before running:
+The Pi builds only from `origin/main`, so anything not pushed and merged there simply won't deploy. Check before running:
 
 ```
 git status --short
@@ -27,7 +27,7 @@ git branch --show-current
 ```
 
 - **Uncommitted changes**: STOP and tell the user — deploying now won't include them; they'd need to commit and push (and merge, per this repo's PR workflow) first.
-- **On `master`**: make sure it's up to date before deploying:
+- **On `main`**: make sure it's up to date before deploying:
   ```
   git fetch origin && git pull
   ```
@@ -35,11 +35,11 @@ git branch --show-current
 
   ```
   git fetch origin
-  git merge-base --is-ancestor HEAD origin/master && echo merged || echo unmerged
+  git merge-base --is-ancestor HEAD origin/main && echo merged || echo unmerged
   ```
 
-  - **Merged** (exit 0 / `merged`): no unique work sits on the branch — deploying `origin/master` is equivalent, proceed.
-  - **Unmerged** (`unmerged`): the branch has commits not yet in `origin/master`. STOP and ask the user before proceeding — deploying right now would build whatever's currently on `origin/master`, not this branch.
+  - **Merged** (exit 0 / `merged`): no unique work sits on the branch — deploying `origin/main` is equivalent, proceed.
+  - **Unmerged** (`unmerged`): the branch has commits not yet in `origin/main`. STOP and ask the user before proceeding — deploying right now would build whatever's currently on `origin/main`, not this branch.
 
 ## 2. Deploy
 
@@ -67,10 +67,10 @@ After the deploy is verified, check for branches that are safe to delete:
 
 ```
 git fetch --prune origin
-git branch --merged master | grep -vE '^\*|^\s*master$'          # stale local branches
-git branch -r --merged origin/master | grep -vE 'origin/master|origin/HEAD'  # stale remote branches
+git branch --merged main | grep -vE '^\*|^\s*main$'          # stale local branches
+git branch -r --merged origin/main | grep -vE 'origin/main|origin/HEAD'  # stale remote branches
 ```
 
-- These are branches already merged into `master`/`origin/master`, so deleting them loses no work — but deletion is still irreversible for anyone with a local checkout of a remote branch you remove.
+- These are branches already merged into `main`/`origin/main`, so deleting them loses no work — but deletion is still irreversible for anyone with a local checkout of a remote branch you remove.
 - List whatever turns up (if anything) and **ask the user before deleting** — never delete branches unprompted. Local: `git branch -d <name>`. Remote: `git push origin --delete <name>`.
 - If nothing is stale, say so briefly and skip the offer — don't ask a hypothetical question when the lists are empty.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   # Fast signal: replays the lockfile verbatim and runs the suites.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Then open http://\<pi-hostname\>:3000 in a browser.
 
 ### Deploying to a Pi
 
-The UI and server deploy the same way: `npm run deploy` runs `scripts/deploy-pi.sh`, which SSHes to the Pi, pulls `origin/master`, installs dependencies, builds the UI, and restarts the service — no local build step, so the Pi always ends up running exactly what's on GitHub.
+The UI and server deploy the same way: `npm run deploy` runs `scripts/deploy-pi.sh`, which SSHes to the Pi, pulls `origin/main`, installs dependencies, builds the UI, and restarts the service — no local build step, so the Pi always ends up running exactly what's on GitHub.
 
 ```bash
 npm run deploy

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Deploys the light panel to the Pi (blinky): pulls origin/master, builds the
+# Deploys the light panel to the Pi (blinky): pulls origin/main, builds the
 # UI there, and restarts the service. Mirrors the server's own deploy path —
 # see the `deploy` skill (.claude/skills/deploy/SKILL.md) for the full
 # checklist (branch preflight, verification, stale-branch cleanup) that


### PR DESCRIPTION
The default branch was renamed `master` → `main` via GitHub's rename endpoint, which redirects web/API requests for the old name but does not touch anything that names the branch as a *string*.

- **`.github/workflows/ci.yml`** — the `push` and `pull_request` filters would have silently stopped matching. This is the only functional change here; CI running on this PR is the proof it took, since `pull_request` events use the head branch's copy of the workflow.
- **`.claude/skills/deploy/SKILL.md`**, **`README.md`** — prose describing `origin/master`.
- **`scripts/deploy-pi.sh`** — header comment only; the script runs a bare `git pull`.

No history was rewritten: a branch rename moves a ref, not the commits it points at.

`packages/server/package.json`'s GitHub URLs point at the old `NeoPixelLightPanel` repo name and carry no branch — left alone as a separate question.

**The Pi's clone is not yet renamed** and `npm run deploy` fails until it is — tracked in #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCL7WkGQj1QF3TwKtywiCT